### PR TITLE
Update key bindings for tmux 2.6

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -19,9 +19,10 @@ set-option -g allow-rename off
 
 # Use Vi navigation in copy mode.
 set-window-option -g mode-keys vi
-bind-key -t vi-copy 'v' begin-selection
-bind-key -t vi-copy 'y' copy-pipe "pbcopy"
-bind-key -t vi-copy 'r' rectangle-toggle
+
+bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
+bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi 'r' send-keys -X rectangle-toggle
 
 # Change status line color to gray.
 set -g status-bg '#666666'


### PR DESCRIPTION
The format for these key bindings has been updated with tmux 2.6 (or even possibly earlier, I haven't updated tmux in quite some time).

These new bindings use the latest format.

See #25 
