### PR TITLE
Replace config with plugin vim-tmux-navigator

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -45,15 +45,6 @@ bind '"' split-window -h -c '#{pane_current_path}'
 unbind '%'
 bind '%' split-window -v -c '#{pane_current_path}'
 
-# Use Ctrl + h/j/k/l to navigate tmux panes (which also permitting this behavior in Vim for navigating splits)
-# See vim plugin and instructions https://github.com/christoomey/vim-tmux-navigator
-# https://robots.thoughtbot.com/seamlessly-navigate-vim-and-tmux-splits
-bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-h) || tmux select-pane -L"
-bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-j) || tmux select-pane -D"
-bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-k) || tmux select-pane -U"
-bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys C-l) || tmux select-pane -R"
-bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iq vim && tmux send-keys 'C-\\') || tmux select-pane -l"
-
 # Resize Pane with large jumps using Alt + Up Arrow (Down, Left, Right)
 # Note: These commands do not require the Tmux prefix
 bind -n M-Up    resize-pane -U 15
@@ -66,6 +57,8 @@ set -g @resurrect-strategy-vim 'session'
 set -g @resurrect-strategy-nvim 'session'
 set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-save-shell-history 'on'
+# Use Ctrl + h/j/k/l to navigate tmux panes (which also permitting this behavior in Vim for navigating splits)
+set -g @plugin 'christoomey/vim-tmux-navigator'
 #
 # tmux plugins (keep this at the very bottom)
 set -g @plugin 'tmux-plugins/tpm'


### PR DESCRIPTION
Replace configuration lines with plugin `christoomey/vim-tmux-navigator`

We were seeing an error with the old configuration and rather than troubleshoot our configuration, we are now using the pre-package tmux plugin for this functionality.

See #31